### PR TITLE
Make atlas sizes configurable and clamp to supported texture size

### DIFF
--- a/common/src/main/java/net/conczin/immersive_furniture/Client.java
+++ b/common/src/main/java/net/conczin/immersive_furniture/Client.java
@@ -16,8 +16,6 @@ import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.world.entity.player.Player;
 
 public class Client {
-    private static final int MAX_ATLAS_SIZE = 8192;
-
     public static final String ATLAS_REFRESH_COMMAND = "/immersive_furniture_refresh_atlas";
     public static final String ATLAS_INCREASE_COMMAND = "/immersive_furniture_increase_atlas";
 
@@ -98,12 +96,13 @@ public class Client {
 
         Config config = Config.getInstance();
         int size = config.getBakedAtlasSize();
-        if (size >= MAX_ATLAS_SIZE) {
+        int max = config.getMaxAtlasSize();
+        if (size >= max) {
             player.sendSystemMessage(Component.translatable("immersive_furniture.atlas_increase.maximum"));
             return;
         }
 
-        config.bakedAtlasSize = Math.min(size * 2, MAX_ATLAS_SIZE);
+        config.bakedAtlasSize = Math.min(size * 2, max);
         config.save();
         player.sendSystemMessage(Component.translatable("immersive_furniture.atlas_increase.restart", config.bakedAtlasSize, config.bakedAtlasSize));
     }

--- a/common/src/main/java/net/conczin/immersive_furniture/client/DelayedFurnitureRenderer.java
+++ b/common/src/main/java/net/conczin/immersive_furniture/client/DelayedFurnitureRenderer.java
@@ -3,6 +3,7 @@ package net.conczin.immersive_furniture.client;
 import net.conczin.immersive_furniture.Common;
 import net.conczin.immersive_furniture.block.BaseFurnitureBlock;
 import net.conczin.immersive_furniture.client.model.DynamicAtlas;
+import net.conczin.immersive_furniture.config.Config;
 import net.conczin.immersive_furniture.data.FurnitureData;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
@@ -19,7 +20,6 @@ import java.util.function.Function;
 public class DelayedFurnitureRenderer {
     public static final DelayedFurnitureRenderer INSTANCE = new DelayedFurnitureRenderer();
 
-    private static final int MAX_ENTITY_ATLAS_SIZE = 8192;
     private static final long ENTITY_ATLAS_RESET_COOLDOWN = TimeUnit.SECONDS.toNanos(10);
 
     private boolean quickCheck = false;
@@ -87,8 +87,9 @@ public class DelayedFurnitureRenderer {
 
         long now = System.nanoTime();
         if (atlas.isFull() && now - lastEntityAtlasReset < ENTITY_ATLAS_RESET_COOLDOWN) {
-            if (atlas.getSize() < MAX_ENTITY_ATLAS_SIZE) {
-                int size = Math.min(atlas.getSize() * 2, MAX_ENTITY_ATLAS_SIZE);
+            int max = Config.getInstance().getMaxAtlasSize();
+            if (atlas.getSize() < max) {
+                int size = Math.min(atlas.getSize() * 2, max);
                 DynamicAtlas.resizeEntity(size);
                 lastEntityAtlasReset = now;
                 Common.logger.info("Resized entity atlas to {}x{}", size, size);

--- a/common/src/main/java/net/conczin/immersive_furniture/client/model/DynamicAtlas.java
+++ b/common/src/main/java/net/conczin/immersive_furniture/client/model/DynamicAtlas.java
@@ -16,8 +16,8 @@ import java.util.concurrent.ConcurrentSkipListSet;
 
 public class DynamicAtlas extends DynamicTexture {
     public static final DynamicAtlas BAKED = new DynamicAtlas(Config.getInstance().getBakedAtlasSize(), "baked");
-    public static DynamicAtlas ENTITY = new DynamicAtlas(512, "entity");
-    public static final DynamicAtlas SCRATCH = new DynamicAtlas(512, "scratch");
+    public static DynamicAtlas ENTITY = new DynamicAtlas(Config.getInstance().getEntityAtlasSize(), "entity");
+    public static final DynamicAtlas SCRATCH = new DynamicAtlas(Config.getInstance().getScratchAtlasSize(), "scratch");
 
     int lastStateId;
     boolean full;

--- a/common/src/main/java/net/conczin/immersive_furniture/config/Config.java
+++ b/common/src/main/java/net/conczin/immersive_furniture/config/Config.java
@@ -38,8 +38,11 @@ public final class Config extends JsonConfig {
     // Lower values may lead to artifacts on steep view angles.
     public int maxMipLevel = 2;
 
-    // Atlas size for baked furniture; must be a multiple of 2, between 512 and 8192
+    // Atlas sizes must be powers of two; invalid values fall back to their default
     public int bakedAtlasSize = 1024;
+    public int entityAtlasSize = 512;
+    public int scratchAtlasSize = 512;
+    public int maxAtlasSize = 8192;
     public boolean disableAtlasRefreshes = false;
 
     public Config(String name) {
@@ -51,10 +54,23 @@ public final class Config extends JsonConfig {
     }
 
     public int getBakedAtlasSize() {
-        return switch (bakedAtlasSize) {
-            case 256, 512, 1024, 2048, 4096, 8192 -> bakedAtlasSize;
-            default -> 1024;
-        };
+        return validAtlasSize(bakedAtlasSize, 1024);
+    }
+
+    public int getEntityAtlasSize() {
+        return validAtlasSize(entityAtlasSize, 512);
+    }
+
+    public int getScratchAtlasSize() {
+        return validAtlasSize(scratchAtlasSize, 512);
+    }
+
+    public int getMaxAtlasSize() {
+        return validAtlasSize(maxAtlasSize, 8192);
+    }
+
+    private static int validAtlasSize(int size, int fallback) {
+        return size > 0 && (size & (size - 1)) == 0 ? size : fallback;
     }
 
     @Override


### PR DESCRIPTION
Extends the configurable `bakedAtlasSize` to the remaining atlases and the growth ceiling, with a hardware guardrail.

- adds `entityAtlasSize` (512), `scratchAtlasSize` (512), and `maxAtlasSize` (8192)
- `maxAtlasSize` replaces the hardcoded 8192 in `Client.MAX_ATLAS_SIZE` and `DelayedFurnitureRenderer.MAX_ENTITY_ATLAS_SIZE`, so one setting governs both the `/immersive_furniture_increase_atlas` ceiling and entity auto-grow
- validation is a power of two check rather than the whitelist, letting modpacks or users opt into larger atlases on capable hardware
- `DynamicAtlas.supportedSize` clamps any requested size to `Integer.highestOneBit(RenderSystem.maxSupportedTextureSize())`, so an over-large config can't exceed GL `MAX_TEXTURE_SIZE`

Defaults match the previous hardcoded values, so behavior is unchanged unless configured.